### PR TITLE
[int-tests] Update MockAsyncServer to have separate basic and topic handlers, move topic tests to separate class

### DIFF
--- a/integration/mock-backend-server/src/main/java/org/wso2/choreo/connect/mockbackend/async/MockAsyncServer.java
+++ b/integration/mock-backend-server/src/main/java/org/wso2/choreo/connect/mockbackend/async/MockAsyncServer.java
@@ -61,13 +61,13 @@ public class MockAsyncServer extends Thread {
         } catch (InterruptedException e) {
             log.error("Interrupted while syncing channel bind or channel close", e);
         } finally {
-            workerGroup.shutdownGracefully();
+            workerGroup.shutdownGracefully().syncUninterruptibly();;
             bossGroup.shutdownGracefully();
         }
     }
 
     static class WebSocketServerInitializer extends ChannelInitializer<SocketChannel> {
-
+        private static final String WEBSOCKET_PATH = "/v2";
         private final SslContext sslCtx;
 
         public WebSocketServerInitializer(SslContext sslCtx) {
@@ -83,7 +83,7 @@ public class MockAsyncServer extends Thread {
             pipeline.addLast(new HttpServerCodec());
             pipeline.addLast(new HttpObjectAggregator(65536));
             pipeline.addLast(new WebSocketServerCompressionHandler());
-            pipeline.addLast(new WsHttpRequestHandler());
+            pipeline.addLast(new WsHttpRequestHandler(WEBSOCKET_PATH));
         }
     }
 }

--- a/integration/mock-backend-server/src/main/java/org/wso2/choreo/connect/mockbackend/async/websocket/WsBasicFrameHandler.java
+++ b/integration/mock-backend-server/src/main/java/org/wso2/choreo/connect/mockbackend/async/websocket/WsBasicFrameHandler.java
@@ -21,26 +21,13 @@ package org.wso2.choreo.connect.mockbackend.async.websocket;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.handler.codec.http.websocketx.BinaryWebSocketFrame;
-import io.netty.handler.codec.http.websocketx.CloseWebSocketFrame;
-import io.netty.handler.codec.http.websocketx.PingWebSocketFrame;
-import io.netty.handler.codec.http.websocketx.PongWebSocketFrame;
 import io.netty.handler.codec.http.websocketx.TextWebSocketFrame;
 import io.netty.handler.codec.http.websocketx.WebSocketFrame;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-
-public class WsServerFrameHandler extends ChannelInboundHandlerAdapter {
-    private static final Logger log = LoggerFactory.getLogger(WsServerFrameHandler.class);
-    private final String customContext;
-
-    public WsServerFrameHandler() {
-        customContext = "";
-    }
-
-    public WsServerFrameHandler(String backendIdentifier) {
-        customContext = backendIdentifier;
-    }
+public class WsBasicFrameHandler extends ChannelInboundHandlerAdapter {
+    private static final Logger log = LoggerFactory.getLogger(WsBasicFrameHandler.class);
 
     @Override
     public void channelRead(ChannelHandlerContext ctx, Object msg) {
@@ -48,17 +35,11 @@ public class WsServerFrameHandler extends ChannelInboundHandlerAdapter {
             if (msg instanceof TextWebSocketFrame) {
                 log.info("TextWebSocketFrame received. Message: {}", ((TextWebSocketFrame) msg).text());
                 ctx.channel().writeAndFlush(
-                        new TextWebSocketFrame("Message received: " + ((TextWebSocketFrame) msg).text() +
-                                customContext));
+                        new TextWebSocketFrame("Message received: " + ((TextWebSocketFrame) msg).text()));
             } else if (msg instanceof BinaryWebSocketFrame) {
-                log.info("BinaryWebSocketFrame received. Message: {}", msg);
+                log.info("BinaryWebSocketFrame received.");
                 ctx.channel().writeAndFlush(
                         new BinaryWebSocketFrame(((BinaryWebSocketFrame) msg).content()));
-            } else if (msg instanceof PingWebSocketFrame) {
-                ctx.channel().writeAndFlush(new PongWebSocketFrame());
-            } else if (msg instanceof CloseWebSocketFrame) {
-                ctx.channel().unsafe().closeForcibly();
-            } else if (msg instanceof PongWebSocketFrame) {
             } else {
                 log.info("Unsupported WebSocketFrame");
             }

--- a/integration/mock-backend-server/src/main/java/org/wso2/choreo/connect/mockbackend/async/websocket/WsTopicFrameHandler.java
+++ b/integration/mock-backend-server/src/main/java/org/wso2/choreo/connect/mockbackend/async/websocket/WsTopicFrameHandler.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2022, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.choreo.connect.mockbackend.async.websocket;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.handler.codec.http.websocketx.WebSocketFrame;
+import io.netty.handler.codec.http.websocketx.TextWebSocketFrame;
+import io.netty.handler.codec.http.websocketx.BinaryWebSocketFrame;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class WsTopicFrameHandler extends ChannelInboundHandlerAdapter {
+    private static final Logger log = LoggerFactory.getLogger(WsBasicFrameHandler.class);
+    private final String topic;
+
+    public WsTopicFrameHandler(String topic) {
+        this.topic = topic;
+    }
+
+    @Override
+    public void channelRead(ChannelHandlerContext ctx, Object msg) {
+        if (msg instanceof WebSocketFrame) {
+            if (msg instanceof TextWebSocketFrame) {
+                log.info("TextWebSocketFrame received. Topic: {} Message: {}", topic,
+                        ((TextWebSocketFrame) msg).text());
+                ctx.channel().writeAndFlush(
+                        new TextWebSocketFrame("Message received: " + ((TextWebSocketFrame) msg).text() +
+                                topic));
+            } else if (msg instanceof BinaryWebSocketFrame) {
+                log.info("BinaryWebSocketFrame received. Topic: {}", topic);
+                ctx.channel().writeAndFlush(
+                        new BinaryWebSocketFrame(((BinaryWebSocketFrame) msg).content()));
+            } else {
+                log.info("Unsupported WebSocketFrame");
+            }
+        }
+    }
+}

--- a/integration/test-integration/src/test/resources/apim/1/apps/applications.json
+++ b/integration/test-integration/src/test/resources/apim/1/apps/applications.json
@@ -54,5 +54,9 @@
   {
     "appName": "WebSocketBasicApp",
     "throttleTier": "Unlimited"
+  },
+  {
+    "appName": "WebSocketTopicApp",
+    "throttleTier": "Unlimited"
   }
 ]

--- a/integration/test-integration/src/test/resources/apim/1/subscriptions/subscriptions.json
+++ b/integration/test-integration/src/test/resources/apim/1/subscriptions/subscriptions.json
@@ -66,7 +66,7 @@
   },
   {
     "apiName": "WebSocketTopicAPI",
-    "appName": "WebSocketBasicApp",
+    "appName": "WebSocketTopicApp",
     "tier": "AsyncUnlimited"
   }
 ]

--- a/integration/test-integration/src/test/resources/testng-cc-with-apim.xml
+++ b/integration/test-integration/src/test/resources/testng-cc-with-apim.xml
@@ -82,6 +82,7 @@
            <class name="org.wso2.choreo.connect.tests.testcases.withapim.RetryAndTimeoutTestCase"/>
            <class name="org.wso2.choreo.connect.tests.testcases.withapim.websocket.WebSocketBasicTestCase"/>
            <class name="org.wso2.choreo.connect.tests.testcases.withapim.websocket.WebSocketSecurityDisabledTestCase"/>
+           <class name="org.wso2.choreo.connect.tests.testcases.withapim.websocket.WebSocketTopicTestCase"/>
        </classes>
    </test>
 


### PR DESCRIPTION
### Purpose
- Update MockAsyncServer to have separate basic and topic handlers
- Use built-in ws protocol handler
- Move topic tests to separate class

### Issues
Related to https://github.com/wso2/product-microgateway/issues/2750

### Automation tests
 - Unit tests added: Yes/No
 - Integration tests added: Yes/No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
Not Tested

---
#### Maintainers: Check before merge
- [ ] Assigned 'Type' label
- [ ] Assigned the project
- [ ] Validated respective github issues
- [ ] Assigned milestone to the github issue(s)
